### PR TITLE
example http context refactoring

### DIFF
--- a/Sample/Profile.fs
+++ b/Sample/Profile.fs
@@ -17,7 +17,7 @@ open Navs.Avalonia
 
 open Threads.Lib
 open Threads.Lib.Profiles
-open Threads.Lib.API
+open Threads.Lib
 
 module Profile =
   open System

--- a/Sample/Program.fs
+++ b/Sample/Program.fs
@@ -11,7 +11,7 @@ open SkiaSharp
 
 open Navs
 open Navs.Avalonia
-open Threads.Lib.API
+open Threads.Lib
 
 let navigate url (router: IRouter<Control>) _ _ =
   async {
@@ -25,7 +25,7 @@ let navigate url (router: IRouter<Control>) _ _ =
 
 let app accessToken () =
 
-  let threads = ThreadClient.Create(accessToken)
+  let threads = Threads.Create(accessToken)
 
   let router =
     AvaloniaRouter(

--- a/Sample/Routes.fs
+++ b/Sample/Routes.fs
@@ -10,7 +10,7 @@ open NXUI.FSharp.Extensions
 open Navs
 open Navs.Avalonia
 
-open Threads.Lib.API
+open Threads.Lib
 
 let getRoutes(threads: ThreadsClient) = [
   Route.define(

--- a/Threads.Lib/Insights.fs
+++ b/Threads.Lib/Insights.fs
@@ -133,23 +133,29 @@ module Insights =
     | Until of until: DateTimeOffset
     | Breakdown of demographicBreakdown: DemographicBreakdown
 
-  let getMediaInsights baseUrl accessToken mediaId (metrics: Metric array) = async {
-    let! req =
-      http {
-        GET $"%s{baseUrl}/%s{mediaId}/threads_insights"
+  let getMediaInsights
+    (baseHttp: HeaderContext)
+    accessToken
+    mediaId
+    (metrics: Metric array)
+    =
+    async {
+      let! req =
+        baseHttp {
+          GET $"%s{mediaId}/threads_insights"
 
-        query [
-          if metrics.Length > 0 then
-            "metric", String.Join(",", Array.map Metric.asString metrics)
-          "access_token", accessToken
-        ]
-      }
-      |> Request.sendAsync
+          query [
+            if metrics.Length > 0 then
+              "metric", String.Join(",", Array.map Metric.asString metrics)
+            "access_token", accessToken
+          ]
+        }
+        |> Request.sendAsync
 
-    let! res = Response.toTextAsync req
+      let! res = Response.toTextAsync req
 
-    return Decode.fromString MediaMetricResponse.Decode res
-  }
+      return Decode.fromString MediaMetricResponse.Decode res
+    }
 
   type InsightError =
     | DateTooEarly
@@ -157,7 +163,7 @@ module Insights =
     | FollowerDemographicsMustIncludeBreakdown
 
   let getUserInsights
-    baseUrl
+    (baseHttp: HeaderContext)
     accessToken
     userId
     (metrics: Metric array)
@@ -218,8 +224,8 @@ module Insights =
       | _ -> ()
 
       let! req =
-        http {
-          GET $"%s{baseUrl}/%s{userId}/threads_insights"
+        baseHttp {
+          GET $"%s{userId}/threads_insights"
 
           query [
             if metrics.Length > 0 then

--- a/Threads.Lib/Insights.fsi
+++ b/Threads.Lib/Insights.fsi
@@ -1,6 +1,7 @@
 namespace Threads.Lib
 
 open System
+open FsHttp
 
 module Insights =
   type DemographicBreakdown =
@@ -48,7 +49,7 @@ module Insights =
     | Breakdown of demographicBreakdown: DemographicBreakdown
 
   val internal getMediaInsights:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     mediaId: string ->
     metrics: Metric array ->
@@ -60,7 +61,7 @@ module Insights =
     | FollowerDemographicsMustIncludeBreakdown
 
   val internal getUserInsights:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     metrics: Metric array ->

--- a/Threads.Lib/Media.fsi
+++ b/Threads.Lib/Media.fsi
@@ -1,6 +1,7 @@
 namespace Threads.Lib
 
 open System
+open FsHttp
 
 module Media =
   [<Struct>]
@@ -60,7 +61,7 @@ module Media =
   }
 
   val internal getThreads:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     profileId: string ->
     pagination: PaginationKind option ->
@@ -68,7 +69,7 @@ module Media =
       Async<Result<ThreadListResponse, string>>
 
   val internal getThread:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     threadId: string ->
     threadFields: ThreadField seq ->

--- a/Threads.Lib/Posts.fs
+++ b/Threads.Lib/Posts.fs
@@ -85,57 +85,63 @@ module Posts =
     | IsTextButNoTextProvided
 
 
-  let createSingleContainer baseUrl accessToken userId postParams = asyncResult {
-    let postParams =
-      postParams
-      |> Seq.filter(fun f ->
-        match f with
-        | CarouselItem -> false
-        | _ -> true)
-      |> Seq.toList
-
-    let mediaType = PostParam.extractMediaType postParams
-
-    match mediaType with
-    | Some Carousel -> do! Error IsCarouselInSingleContainer
-    | Some Image ->
-      do!
+  let createSingleContainer
+    (baseHttp: HeaderContext)
+    accessToken
+    userId
+    postParams
+    =
+    asyncResult {
+      let postParams =
         postParams
-        |> PostParam.extractImageUrl
-        |> Result.requireSome IsImageButImageNotProvided
-        |> Result.ignore
-    | Some Video ->
-      do!
-        postParams
-        |> PostParam.extractVideoUrl
-        |> Result.requireSome IsVideoButNoVideoProvided
-        |> Result.ignore
-    | Some MediaType.Text
-    | None ->
-      do!
-        postParams
-        |> PostParam.extractText
-        |> Result.requireSome IsTextButNoTextProvided
-        |> Result.ignore
+        |> Seq.filter(fun f ->
+          match f with
+          | CarouselItem -> false
+          | _ -> true)
+        |> Seq.toList
 
-    let postParams = postParams |> List.map PostParam.toStringTuple
+      let mediaType = PostParam.extractMediaType postParams
 
-    let! req =
-      http {
-        POST $"%s{baseUrl}/%s{userId}/threads"
+      match mediaType with
+      | Some Carousel -> do! Error IsCarouselInSingleContainer
+      | Some Image ->
+        do!
+          postParams
+          |> PostParam.extractImageUrl
+          |> Result.requireSome IsImageButImageNotProvided
+          |> Result.ignore
+      | Some Video ->
+        do!
+          postParams
+          |> PostParam.extractVideoUrl
+          |> Result.requireSome IsVideoButNoVideoProvided
+          |> Result.ignore
+      | Some MediaType.Text
+      | None ->
+        do!
+          postParams
+          |> PostParam.extractText
+          |> Result.requireSome IsTextButNoTextProvided
+          |> Result.ignore
 
-        query [
-          yield! postParams
-          "is_carousel_item", "false"
-          "access_token", accessToken
-        ]
-      }
-      |> Request.sendAsync
+      let postParams = postParams |> List.map PostParam.toStringTuple
 
-    let! (response: PostId) = req |> Response.deserializeJsonAsync
+      let! req =
+        baseHttp {
+          POST $"%s{userId}/threads"
 
-    return response
-  }
+          query [
+            yield! postParams
+            "is_carousel_item", "false"
+            "access_token", accessToken
+          ]
+        }
+        |> Request.sendAsync
+
+      let! (response: PostId) = req |> Response.deserializeJsonAsync
+
+      return response
+    }
 
   [<Struct>]
   type CarouselItemContainerError =
@@ -143,95 +149,114 @@ module Posts =
     | IsImageButImageNotProvided
     | IsVideoButNoVideoProvided
 
-  let createCarouselItemContainer baseUrl accessToken userId postParams = asyncResult {
-    let postParams =
-      postParams
-      |> Seq.filter(fun f ->
-        match f with
-        | CarouselItem -> false
-        | _ -> true)
-      |> Seq.toList
-
-    let mediaType = PostParam.extractMediaType postParams
-
-    match mediaType with
-    | Some Carousel
-    | Some MediaType.Text
-    | None -> do! Error MediaTypeMustbeVideoOrImage
-    | Some Image ->
-      do!
+  let createCarouselItemContainer
+    (baseHttp: HeaderContext)
+    accessToken
+    userId
+    postParams
+    =
+    asyncResult {
+      let postParams =
         postParams
-        |> PostParam.extractImageUrl
-        |> Result.requireSome IsImageButImageNotProvided
-        |> Result.ignore
-    | Some Video ->
-      do!
-        postParams
-        |> PostParam.extractVideoUrl
-        |> Result.requireSome IsVideoButNoVideoProvided
-        |> Result.ignore
+        |> Seq.filter(fun f ->
+          match f with
+          | CarouselItem -> false
+          | _ -> true)
+        |> Seq.toList
 
-    let postParams = postParams |> List.map PostParam.toStringTuple
+      let mediaType = PostParam.extractMediaType postParams
 
-    let! req =
-      http {
-        POST $"%s{baseUrl}/%s{userId}/threads"
+      match mediaType with
+      | Some Carousel
+      | Some MediaType.Text
+      | None -> do! Error MediaTypeMustbeVideoOrImage
+      | Some Image ->
+        do!
+          postParams
+          |> PostParam.extractImageUrl
+          |> Result.requireSome IsImageButImageNotProvided
+          |> Result.ignore
+      | Some Video ->
+        do!
+          postParams
+          |> PostParam.extractVideoUrl
+          |> Result.requireSome IsVideoButNoVideoProvided
+          |> Result.ignore
 
-        query [
-          yield! postParams
-          "is_carousel_item", "true"
-          "access_token", accessToken
-        ]
-      }
-      |> Request.sendAsync
+      let postParams = postParams |> List.map PostParam.toStringTuple
 
-    let! (response: PostId) = req |> Response.deserializeJsonAsync
+      let! req =
+        baseHttp {
+          POST $"%s{userId}/threads"
 
-    return response
-  }
+          query [
+            yield! postParams
+            "is_carousel_item", "true"
+            "access_token", accessToken
+          ]
+        }
+        |> Request.sendAsync
+
+      let! (response: PostId) = req |> Response.deserializeJsonAsync
+
+      return response
+    }
 
   [<Struct>]
   type CarouselContainerError =
     | MoreThan10Children
     | CarouselPostIsEmpty
 
-  let createCarouselContainer baseUrl accessToken userId children textContent = asyncResult {
-    let children = children |> Seq.map _.id |> Seq.toList
+  let createCarouselContainer
+    (baseHttp: HeaderContext)
+    accessToken
+    userId
+    children
+    textContent
+    =
+    asyncResult {
+      let children = children |> Seq.map _.id |> Seq.toList
 
-    do! children.Length = 0 |> Result.requireFalse CarouselPostIsEmpty
-    do! children.Length > 10 |> Result.requireFalse MoreThan10Children
-    let children = String.Join(",", children)
+      do! children.Length = 0 |> Result.requireFalse CarouselPostIsEmpty
+      do! children.Length > 10 |> Result.requireFalse MoreThan10Children
+      let children = String.Join(",", children)
 
-    let! req =
-      http {
-        POST $"%s{baseUrl}/%s{userId}/threads"
+      let! req =
+        baseHttp {
+          POST $"%s{userId}/threads"
 
-        query [
-          "media_type", "CAROUSEL"
-          "children", children
-          match textContent with
-          | Some text -> "text", text
-          | None -> ()
-          "access_token", accessToken
-        ]
-      }
-      |> Request.sendAsync
+          query [
+            "media_type", "CAROUSEL"
+            "children", children
+            match textContent with
+            | Some text -> "text", text
+            | None -> ()
+            "access_token", accessToken
+          ]
+        }
+        |> Request.sendAsync
 
-    let! (response: PostId) = req |> Response.deserializeJsonAsync
+      let! (response: PostId) = req |> Response.deserializeJsonAsync
 
-    return response
-  }
+      return response
+    }
 
-  let publishContainer baseUrl accessToken userId containerId = async {
-    let! req =
-      http {
-        POST $"%s{baseUrl}/%s{userId}/threads_publish"
+  let publishContainer
+    (baseHttp: HeaderContext)
+    accessToken
+    userId
+    containerId
+    =
+    async {
+      let! req =
+        baseHttp {
+          POST $"%s{userId}/threads_publish"
 
-        query [ "creation_id", containerId.id; "access_token", accessToken ]
-      }
-      |> Request.sendAsync
+          query [ "creation_id", containerId.id; "access_token", accessToken ]
+        }
+        |> Request.sendAsync
 
-    let! (response: PostId) = req |> Response.deserializeJsonAsync
+      let! (response: PostId) = req |> Response.deserializeJsonAsync
 
-    return response
-  }
+      return response
+    }

--- a/Threads.Lib/Posts.fsi
+++ b/Threads.Lib/Posts.fsi
@@ -1,6 +1,7 @@
 namespace Threads.Lib
 
 open System
+open FsHttp
 
 module Posts =
   [<Struct>]
@@ -36,7 +37,7 @@ module Posts =
     | IsTextButNoTextProvided
 
   val internal createSingleContainer:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     postParams: PostParam seq ->
@@ -49,7 +50,7 @@ module Posts =
     | IsVideoButNoVideoProvided
 
   val internal createCarouselItemContainer:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     postParams: PostParam seq ->
@@ -61,7 +62,7 @@ module Posts =
     | CarouselPostIsEmpty
 
   val internal createCarouselContainer:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     children: PostId seq ->
@@ -69,7 +70,7 @@ module Posts =
       Async<Result<PostId, CarouselContainerError>>
 
   val internal publishContainer:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     containerId: PostId ->

--- a/Threads.Lib/Profiles.fs
+++ b/Threads.Lib/Profiles.fs
@@ -73,7 +73,7 @@ module Profiles =
         |> decodeThreadsBiography
         |> finish)
 
-  let getProfile baseUrl accessToken profileId profileFields = async {
+  let getProfile (baseHttp: HeaderContext) accessToken profileId profileFields = async {
     let fields =
       profileFields
       |> Seq.map ProfileField.asString
@@ -85,8 +85,8 @@ module Profiles =
       | None -> "me"
 
     let! req =
-      http {
-        GET $"%s{baseUrl}/%s{profileId}"
+      baseHttp {
+        GET $"%s{profileId}"
 
         query [
           if String.IsNullOrEmpty fields then () else "fields", fields

--- a/Threads.Lib/Profiles.fsi
+++ b/Threads.Lib/Profiles.fsi
@@ -3,7 +3,6 @@ namespace Threads.Lib
 open System
 
 open FsHttp
-open Thoth.Json.Net
 
 module Profiles =
   [<Struct>]
@@ -20,7 +19,7 @@ module Profiles =
     | ThreadsBiography of string
 
   val internal getProfile:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     profileId: string option ->
     profileFields: ProfileField seq ->

--- a/Threads.Lib/ReplyManagement.fsi
+++ b/Threads.Lib/ReplyManagement.fsi
@@ -1,6 +1,5 @@
 namespace Threads.Lib
 
-open Thoth.Json.Net
 open FsHttp
 
 module ReplyManagement =
@@ -102,14 +101,14 @@ module ReplyManagement =
   }
 
   val internal getRateLimits:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     fields: RateLimitField seq ->
       Async<Result<RateLimitResponse, string>>
 
   val internal getReplies:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     mediaId: string ->
     fields: ReplyField seq ->
@@ -117,7 +116,7 @@ module ReplyManagement =
       Async<Result<ConversationResponse, string>>
 
   val internal getConversations:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     mediaId: string ->
     fields: ReplyField seq ->
@@ -125,14 +124,14 @@ module ReplyManagement =
       Async<Result<ConversationResponse, string>>
 
   val internal getUserReplies:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     userId: string ->
     fields: ReplyField seq ->
       Async<Result<ConversationResponse, string>>
 
   val internal manageReply:
-    baseUrl: string ->
+    baseHttp: HeaderContext ->
     accessToken: string ->
     replyId: string ->
     shouldHide: bool ->

--- a/Threads.Lib/Threads.fs
+++ b/Threads.Lib/Threads.fs
@@ -65,18 +65,19 @@ type ThreadClient =
     let baseHttp = http { config_useBaseUrl baseUrl }
 
     let fetchProfile = Threads.Lib.Profiles.getProfile baseHttp accessToken
-    let fetchThreads = Threads.Lib.Media.getThreads baseUrl accessToken
-    let fetchThread = Threads.Lib.Media.getThread baseUrl accessToken
+    let fetchThreads = Threads.Lib.Media.getThreads baseHttp accessToken
+    let fetchThread = Threads.Lib.Media.getThread baseHttp accessToken
 
     let postCarousel =
-      Threads.Lib.Posts.createCarouselContainer baseUrl accessToken
+      Threads.Lib.Posts.createCarouselContainer baseHttp accessToken
 
-    let postSingle = Threads.Lib.Posts.createSingleContainer baseUrl accessToken
+    let postSingle =
+      Threads.Lib.Posts.createSingleContainer baseHttp accessToken
 
     let postCarouselItem =
-      Threads.Lib.Posts.createCarouselItemContainer baseUrl accessToken
+      Threads.Lib.Posts.createCarouselItemContainer baseHttp accessToken
 
-    let publishPost = Threads.Lib.Posts.publishContainer baseUrl accessToken
+    let publishPost = Threads.Lib.Posts.publishContainer baseHttp accessToken
 
     { new ThreadsClient with
 

--- a/Threads.Lib/Threads.fs
+++ b/Threads.Lib/Threads.fs
@@ -2,6 +2,7 @@ namespace Threads.Lib.API
 
 open System.Threading
 open System.Threading.Tasks
+open FsHttp
 
 
 type PostService =
@@ -61,8 +62,9 @@ type ThreadClient =
 
   static member Create(accessToken: string, ?baseUrl: string) : ThreadsClient =
     let baseUrl = defaultArg baseUrl "https://graph.threads.net/v1.0/"
+    let baseHttp = http { config_useBaseUrl baseUrl }
 
-    let fetchProfile = Threads.Lib.Profiles.getProfile baseUrl accessToken
+    let fetchProfile = Threads.Lib.Profiles.getProfile baseHttp accessToken
     let fetchThreads = Threads.Lib.Media.getThreads baseUrl accessToken
     let fetchThread = Threads.Lib.Media.getThread baseUrl accessToken
 

--- a/Threads.Lib/Threads.fsi
+++ b/Threads.Lib/Threads.fsi
@@ -1,10 +1,9 @@
-namespace Threads.Lib.API
+namespace Threads.Lib
 
+open FsHttp
 open System.Threading
 open System.Threading.Tasks
 open System.Runtime.InteropServices
-
-open Threads.Lib
 
 type InsightsService =
   abstract FetchMediaInsights:
@@ -108,5 +107,7 @@ type ThreadsClient =
   abstract Insights: InsightsService
 
 [<Class>]
-type ThreadClient =
-  static member Create: accessToken: string -> ThreadsClient
+type Threads =
+  static member Create:
+    accessToken: string * [<OptionalAttribute>] ?headerContext: HeaderContext ->
+      ThreadsClient


### PR DESCRIPTION
In [FsHttp](https://fsprojects.github.io/FsHttp/Composability.html) is possible to refactor clients, so the computation expressions contain less boilerplate code.

The change suggests how this could be done in this project. It's possible to create a client that has the base URL for Threads.net API, and then pass that client to any function that needs to use it.

Example:
```fsharp
let baseHttp = http { config_useBaseUrl baseUrl }
```

```fsharp
let myFunc baseHttp = 
  baseHttp {
     GET …
  }
```